### PR TITLE
Enhance package.json with engine and license checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,15 @@
   "bugs": {
     "url": "https://github.com/a8cteam51/build-processes-demo/issues"
   },
+  "engines": {
+    "node": ">=16.0",
+    "npm": ">=7.0"
+  },
   "devDependencies": {
     "@wordpress/scripts": "latest"
   },
   "scripts": {
-
+    "check-engines": "wp-scripts check-engines",
+    "check-licenses": "wp-scripts check-licenses"
   }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hint that `npm 7` or newer is preferred for building the project. When v2 of the lockfiles was introduced. Bundled with `npm 15`.
* Hint that `node 16` or newer is preferred for building the project. Current LTS version.
* Use `@wordpress/scripts` commands for checking compatibility.

#### Testing instructions

* Add a package with [a non-GPL compatible license](https://www.gnu.org/licenses/license-list.en.html) and then run `npx check-licenses`. You should see an error.
* Switch you version of `npm` and/or `node` (using `nvm`, for example) to a lower version than 7 and 16, respectively, and then run `npx check-engines`. You should see an error.

