### PR TITLE
Proposed theme folder structure

### DIFF
--- a/themes/build-processes-demo/assets/css/build/index.php
+++ b/themes/build-processes-demo/assets/css/build/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/themes/build-processes-demo/assets/css/src/index.php
+++ b/themes/build-processes-demo/assets/css/src/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/themes/build-processes-demo/assets/img/index.php
+++ b/themes/build-processes-demo/assets/img/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/themes/build-processes-demo/assets/index.php
+++ b/themes/build-processes-demo/assets/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/themes/build-processes-demo/assets/js/build/index.php
+++ b/themes/build-processes-demo/assets/js/build/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/themes/build-processes-demo/assets/js/src/index.php
+++ b/themes/build-processes-demo/assets/js/src/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/themes/build-processes-demo/functions.php
+++ b/themes/build-processes-demo/functions.php
@@ -10,3 +10,12 @@
  */
 
 defined( 'ABSPATH' ) || exit;
+
+// Include the rest of the theme functionality.
+foreach ( glob( get_stylesheet_directory() . '/includes/*.php' ) as $filename ) {
+	if ( preg_match( '#/includes/_#i', $filename ) ) {
+		continue; // Ignore files prefixed with an underscore.
+	}
+
+	include $filename;
+}

--- a/themes/build-processes-demo/includes/index.php
+++ b/themes/build-processes-demo/includes/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.

--- a/themes/build-processes-demo/languages/index.php
+++ b/themes/build-processes-demo/languages/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.


### PR DESCRIPTION
Following the example of Gutenberg blocks (and webpack even), I propose to build out the `assets` folder like this:

\- /assets
-- /img
-- /css
--- /build
--- /src
-- /js
--- /build
--- /src

Since the source and the compiled files are nested equally deep, there should be no problems that arise from referencing resources (like images) through relative URLs.

Moreover, in case there is nothing to compile, the structure can stay the same but there will be no `src` and `build` sub-folders.