### PR TITLE
Configure browser support on-par with WP itself

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
+        "@wordpress/browserslist-config": "latest",
         "@wordpress/scripts": "latest"
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
     "url": "https://github.com/a8cteam51/build-processes-demo/issues"
   },
   "devDependencies": {
+    "@wordpress/browserslist-config": "latest",
     "@wordpress/scripts": "latest"
   },
+  "browserslist": [
+    "extends @wordpress/browserslist-config"
+  ],
   "scripts": {
 
   }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `@wordpress/browsserslist-config` to the list of packages and extends `packages.json` to make use of it.

**Technically,** the `@wordpress/browsserslist-config` package is already being added by the `@wordpress/scripts` package. But it's non-obvious, and we wouldn't want this to stop working just in case a project removes `@wordpress/scripts`.

#### Testing instructions

* Running `npx browserslist` should output a list of browsers that is identical to the one advertised [here](https://make.wordpress.org/core/handbook/best-practices/browser-support/)
