### PR TITLE
Asset linting and formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,13 @@
       "version": "1.0.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
-        "@wordpress/browserslist-config": "latest",
-        "@wordpress/scripts": "latest"
+        "@wordpress/browserslist-config": "^5.5.0",
+        "@wordpress/scripts": "^24.6.0",
+        "npm-run-all": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=16.0",
+        "npm": ">=7.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1787,13 +1792,13 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.19.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.19.6.tgz",
-      "integrity": "sha512-oWNn1ZlGde7b4i/3tnixpH9qI0bOAACiUs+KEES4UUCnsPjVWFlWdLV/iwJuPC2qp3EowbAqsm+0XqNwnwYhxA==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.1.tgz",
+      "integrity": "sha512-CGulbEDcg/ND1Im7fUNRZdGXmX2MTWVVZacQi/6DiKE5HNwZ3aVTm5PV4lO8HHz0B2h8WQyvKKjbX5XgTtydsg==",
       "dev": true,
       "dependencies": {
         "core-js-pure": "^3.25.1",
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1978,14 +1983,14 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
-      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       },
       "engines": {
         "node": ">=10.10.0"
@@ -2927,9 +2932,9 @@
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
+      "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
@@ -3220,9 +3225,9 @@
       }
     },
     "node_modules/@types/babel__core": {
-      "version": "7.1.19",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
-      "integrity": "sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==",
+      "version": "7.1.20",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.20.tgz",
+      "integrity": "sha512-PVb6Bg2QuscZ30FvOU7z4guG6c926D9YRvOxEaelzndpMsvP+YM74Q/dAFASpg2l6+XLalxSGxcq/lrgYWZtyQ==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -3472,9 +3477,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.50",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.50.tgz",
-      "integrity": "sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==",
+      "version": "17.0.52",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.52.tgz",
+      "integrity": "sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -3483,9 +3488,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.17",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.17.tgz",
-      "integrity": "sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==",
+      "version": "17.0.18",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.18.tgz",
+      "integrity": "sha512-rLVtIfbwyur2iFKykP2w0pl/1unw26b5td16d5xMgp7/yjTHomkyxPYChFoCr/FtEX1lN9wY6lFj1qvKdS5kDw==",
       "dev": true,
       "dependencies": {
         "@types/react": "^17"
@@ -3504,9 +3509,9 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.3.12",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
-      "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
     },
     "node_modules/@types/serve-index": {
@@ -3642,16 +3647,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.1.tgz",
-      "integrity": "sha512-FsWboKkWdytGiXT5O1/R9j37YgcjO8MKHSUmWnIEjVaz0krHkplPnYi7mwdb+5+cs0toFNQb0HIrN7zONdIEWg==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.43.0.tgz",
+      "integrity": "sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.40.1",
-        "@typescript-eslint/type-utils": "5.40.1",
-        "@typescript-eslint/utils": "5.40.1",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/type-utils": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
@@ -3707,12 +3713,12 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.40.1.tgz",
-      "integrity": "sha512-lynjgnQuoCgxtYgYWjoQqijk0kYQNiztnVhoqha3N0kMYFVPURidzCq2vn9XvUUu2XxP130ZRKVDKyeGa2bhbw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.43.0.tgz",
+      "integrity": "sha512-WkT637CumTJbm/hRbFfnHBMgfUYTKr08LitVsD7gQId7bi6rnkx3pu3jac67lmp5ObW4MpJ9SNFZAIOUB/Qbsw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.40.1"
+        "@typescript-eslint/utils": "5.43.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3726,14 +3732,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.40.1.tgz",
-      "integrity": "sha512-IK6x55va5w4YvXd4b3VrXQPldV9vQTxi5ov+g4pMANsXPTXOcfjx08CRR1Dfrcc51syPtXHF5bgLlMHYFrvQtg==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.43.0.tgz",
+      "integrity": "sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.40.1",
-        "@typescript-eslint/types": "5.40.1",
-        "@typescript-eslint/typescript-estree": "5.40.1",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3753,13 +3759,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.1.tgz",
-      "integrity": "sha512-jkn4xsJiUQucI16OLCXrLRXDZ3afKhOIqXs4R3O+M00hdQLKR58WuyXPZZjhKLFCEP2g+TXdBRtLQ33UfAdRUg==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.43.0.tgz",
+      "integrity": "sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.40.1",
-        "@typescript-eslint/visitor-keys": "5.40.1"
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/visitor-keys": "5.43.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3770,13 +3776,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.40.1.tgz",
-      "integrity": "sha512-DLAs+AHQOe6n5LRraXiv27IYPhleF0ldEmx6yBqBgBLaNRKTkffhV1RPsjoJBhVup2zHxfaRtan8/YRBgYhU9Q==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.43.0.tgz",
+      "integrity": "sha512-K21f+KY2/VvYggLf5Pk4tgBOPs2otTaIHy2zjclo7UZGLyFH86VfUOm5iq+OtDtxq/Zwu2I3ujDBykVW4Xtmtg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.40.1",
-        "@typescript-eslint/utils": "5.40.1",
+        "@typescript-eslint/typescript-estree": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -3797,9 +3803,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.1.tgz",
-      "integrity": "sha512-Icg9kiuVJSwdzSQvtdGspOlWNjVDnF3qVIKXdJ103o36yRprdl3Ge5cABQx+csx960nuMF21v8qvO31v9t3OHw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.43.0.tgz",
+      "integrity": "sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3810,13 +3816,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.1.tgz",
-      "integrity": "sha512-5QTP/nW5+60jBcEPfXy/EZL01qrl9GZtbgDZtDPlfW5zj/zjNrdI2B5zMUHmOsfvOr2cWqwVdWjobCiHcedmQA==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.43.0.tgz",
+      "integrity": "sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.40.1",
-        "@typescript-eslint/visitor-keys": "5.40.1",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/visitor-keys": "5.43.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -3870,16 +3876,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.40.1.tgz",
-      "integrity": "sha512-a2TAVScoX9fjryNrW6BZRnreDUszxqm9eQ9Esv8n5nXApMW0zeANUYlwh/DED04SC/ifuBvXgZpIK5xeJHQ3aw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.43.0.tgz",
+      "integrity": "sha512-8nVpA6yX0sCjf7v/NDfeaOlyaIIqL7OaIGOWSPFqUKK59Gnumd3Wa+2l8oAaYO2lk0sO+SbWFWRSvhu8gLGv4A==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.40.1",
-        "@typescript-eslint/types": "5.40.1",
-        "@typescript-eslint/typescript-estree": "5.40.1",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -3929,12 +3935,12 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.1.tgz",
-      "integrity": "sha512-A2DGmeZ+FMja0geX5rww+DpvILpwo1OsiQs0M+joPWJYsiEFBLsH0y1oFymPNul6Z5okSmHpP4ivkc2N0Cgfkw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.43.0.tgz",
+      "integrity": "sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/types": "5.43.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -4137,9 +4143,9 @@
       }
     },
     "node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.3.0.tgz",
-      "integrity": "sha512-7AnWnpItOqH5YEcFA3RgxeOlb96R8KDWDPAZjZ6TpsdOVjFynT8H3Buc4v127BHmxuxKGyd2vxPIQIzC9dLzOw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.5.0.tgz",
+      "integrity": "sha512-/5TZUHgy4fh7L1aQJPQ8dKjaWBio41uiR4Y9aGH0oeg6pXdQlEOtbAXQtTAHeGyE1vJMYJUVHdRWdLocpGQWgA==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -4149,9 +4155,9 @@
       }
     },
     "node_modules/@wordpress/babel-preset-default": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.4.0.tgz",
-      "integrity": "sha512-7drcVBIajDE8s3At7yUr9UdHROYkfPYgR4OaG+EugDn9MzuDIEsGalnazDYwvjerLAwsf8S/S8o34bi6IrthYQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.6.0.tgz",
+      "integrity": "sha512-DVwF85jvgGR6ExSIOsJKBj2v5vWO2AsrKUs5Vg9vTG7YdkR23JENBOiORYPgYWIdbK7JmSIXEPyfL7HpdvNp9A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -4160,10 +4166,10 @@
         "@babel/preset-env": "^7.16.0",
         "@babel/preset-typescript": "^7.16.0",
         "@babel/runtime": "^7.16.0",
-        "@wordpress/babel-plugin-import-jsx-pragma": "^4.3.0",
-        "@wordpress/browserslist-config": "^5.3.0",
-        "@wordpress/element": "^4.18.0",
-        "@wordpress/warning": "^2.20.0",
+        "@wordpress/babel-plugin-import-jsx-pragma": "^4.5.0",
+        "@wordpress/browserslist-config": "^5.5.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/warning": "^2.22.0",
         "browserslist": "^4.17.6",
         "core-js": "^3.19.1"
       },
@@ -4172,24 +4178,24 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.11.0.tgz",
-      "integrity": "sha512-KGHGtOP8q4u3DhlDsw4mMxlcnqxFPMsPa2GrbFBFgFEMeC/v9XMJAAY97V93D5Tbz1JaWBXjQHI+FwPFuyvCHQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.13.0.tgz",
+      "integrity": "sha512-ivIj7cANk0ML+krX+MnprJMTvLy9l9k/TCuTyrYKx9JRbo2khq+eOvuTsdB9cKcTh7/xMMwNaJ7dn5RAYRb/VQ==",
       "dev": true
     },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.3.0.tgz",
-      "integrity": "sha512-FIhYWu36TrZ49W+knaRwhw3Q+cxaTDEzSaiE83qMDeAPJytT/UaedoJULt5MfxUtfaKLmUa8bPjSFORxoxwbvQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.5.0.tgz",
+      "integrity": "sha512-M3BhWQ+R8AK2g861hOtLTp/WnjcXPddiNzoMHR5zQOhcuSmgfP4dNJIJUWIVRPhqpES2EGcc30F9MIEyV27WiQ==",
       "dev": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.3.0.tgz",
-      "integrity": "sha512-GVQlG0kwPDQj4sYJrYAOuvc0ggrpH75ljV+xGNdy3KPMmrVzhaYEnDSuajlOvpcFyoueMagRJOH84StB76tcMg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.5.0.tgz",
+      "integrity": "sha512-eLzWb/TftHiPzl8ZgwuCPhW0ir9/1VVzVgsag7DyhjyrESLD4YWRqTaE1M1qf6lRP9kjYvBLFZ0TKuLT90Iayg==",
       "dev": true,
       "dependencies": {
         "json2php": "^0.0.5",
@@ -4203,15 +4209,15 @@
       }
     },
     "node_modules/@wordpress/element": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.18.0.tgz",
-      "integrity": "sha512-+3gA4RTD/EDj1h2y/qikh+h0uCUxhShfM7QoDngKOBNSTZHqc0W2p6IMEe+AMdrmu8tyZboTJW/eONjUHE4n7g==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
+      "integrity": "sha512-Ou7EoGtGe4FUL6fKALINXJLKoSfyWTBJzkJfN2HzSgM1wira9EuWahl8MQN0HAUaWeOoDqMKPvnglfS+kC8JLA==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@types/react": "^17.0.37",
         "@types/react-dom": "^17.0.11",
-        "@wordpress/escape-html": "^2.20.0",
+        "@wordpress/escape-html": "^2.22.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^17.0.2",
@@ -4222,9 +4228,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.20.0.tgz",
-      "integrity": "sha512-bhHkFQrEkuJjhSB6OlQq/Kq+43k8E6JwUw/pCDAjJX2uU/DDG3tW3eftYn2ae7W23bPrNEs1/qULWzbaziPQnw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.22.0.tgz",
+      "integrity": "sha512-GUo6VLugIZxen1rdYuotvz6Vqa+5fNtVelNjXLwDqRu0iY2RXeoTux9V5bZWXPnGb54ryqfYmR4gH6F8xZhWzQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0"
@@ -4234,16 +4240,16 @@
       }
     },
     "node_modules/@wordpress/eslint-plugin": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-13.4.0.tgz",
-      "integrity": "sha512-318QjzGildIdHJVAT26CFkYzoXW8w3RUTNzDJrJ+Hx9EHCg2TNOrUwW4rLwp9h32Gsw/QerhF9wzE/pueoYdYw==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-13.6.0.tgz",
+      "integrity": "sha512-GIW4AHb0IC9VA6y8IRGQpADxpvdG+K0an/ZpzlYmBudql7YuLlUmp9rLpBlSvHf9iGX81OUYl9B63XEItPzGEw==",
       "dev": true,
       "dependencies": {
         "@babel/eslint-parser": "^7.16.0",
         "@typescript-eslint/eslint-plugin": "^5.3.0",
         "@typescript-eslint/parser": "^5.3.0",
-        "@wordpress/babel-preset-default": "^7.4.0",
-        "@wordpress/prettier-config": "^2.3.0",
+        "@wordpress/babel-preset-default": "^7.6.0",
+        "@wordpress/prettier-config": "^2.5.0",
         "cosmiconfig": "^7.0.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.25.2",
@@ -4303,9 +4309,9 @@
       }
     },
     "node_modules/@wordpress/jest-console": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-6.3.0.tgz",
-      "integrity": "sha512-WnpXPqRNTo7OBnUEvC7mJufEZUNZXlScnRx3MHFOErzhCzed03t+x2hQHamhYpUrE2hZLwfKugN9WYDzh2mTtA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-6.5.0.tgz",
+      "integrity": "sha512-DqqilY6+FMJHcrUJhAu059iTIFKOXqoWuh0X7MXTGyW4S29n6V4Tzyy8TNhn074R3hjCIqgXo3yF3QXL8uLefQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
@@ -4319,12 +4325,12 @@
       }
     },
     "node_modules/@wordpress/jest-preset-default": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-10.1.0.tgz",
-      "integrity": "sha512-FzMUu31TGv9nLjBTNnMD6EZRU8oYEcDVCg/oUHBv2Rc9GipOgVZB5yRpZA1oAVSxirIvenv0wQ4PGouPAPgcIQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-10.3.0.tgz",
+      "integrity": "sha512-ObyBTM0tIVONU6xmBkgCcl8mrY9hAk+2ZuIrwze5DHVx6dZzeASxouxbgutHOQNu7cHMtVNJ7O5I1XZ7KlhWig==",
       "dev": true,
       "dependencies": {
-        "@wordpress/jest-console": "^6.3.0",
+        "@wordpress/jest-console": "^6.5.0",
         "babel-jest": "^27.4.5"
       },
       "engines": {
@@ -4338,9 +4344,9 @@
       }
     },
     "node_modules/@wordpress/npm-package-json-lint-config": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.5.0.tgz",
-      "integrity": "sha512-UdPtZmvBKI6ygsLsGMxDJjt9H2S2M//rHSSHPMpy5nmLGft890c0+cQwoIPhJpGis3pC5r1Bh8zCrzVZqoBHVQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.7.0.tgz",
+      "integrity": "sha512-sNNaMxA9NwC9ns1Ez/Fd61SULUtDjKWalDMoRX32RpSeNKmcAs2s7vAjDm7xY0NoXX6DPKnU1iftE2mu/8YqVg==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -4350,12 +4356,12 @@
       }
     },
     "node_modules/@wordpress/postcss-plugins-preset": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.4.0.tgz",
-      "integrity": "sha512-KAy+HqPbl/yHGsvWgzfRPonQM7hJ1Zy6ABuwFAk/gqTy2v28InBhyZLSVJAjxMgh0Cxfyfgn+XYIHwlzMTvTXg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.6.0.tgz",
+      "integrity": "sha512-d7wx4lSFGXQBdaKq0SE987IYeC6YhQOr3TlUG1fA9+DFwCpzm3zYxAiDQ8QCMY1y4Di9+3/GgUlaD6MJc60BxA==",
       "dev": true,
       "dependencies": {
-        "@wordpress/base-styles": "^4.11.0",
+        "@wordpress/base-styles": "^4.13.0",
         "autoprefixer": "^10.2.5"
       },
       "engines": {
@@ -4366,9 +4372,9 @@
       }
     },
     "node_modules/@wordpress/prettier-config": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-2.3.0.tgz",
-      "integrity": "sha512-eqeiUvwogvtVTFZ+H0ZRY2EZNBXiyw3XbqGbi4Om15yAaMrnlm8NfUow2yHepYKkW/wWVr1tqBFQN7gZBPtYCQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-2.5.0.tgz",
+      "integrity": "sha512-YI7CwUScwFW3N6PCH6IH2tvnfgkhAYEnYDOJ30JG2P0E3vXG6lnvrdVpQyKlEsGqUDy3FBcTPIP/m3/SHpp6Iw==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -4378,23 +4384,23 @@
       }
     },
     "node_modules/@wordpress/scripts": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-24.4.0.tgz",
-      "integrity": "sha512-MpF2dFknFIEMIZV8lCNlfktHV4WNrUZDirKXkKafdYWxtiuPn8vXgvU9E2tI1PERpaMEQvx75ot5LBB2C5TErw==",
+      "version": "24.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-24.6.0.tgz",
+      "integrity": "sha512-IbJkihQsjaZz03qyTPcjRF2FWiVVcCm90eL/QutO9cSmZbqfAT1hwNSZIEakiy7GK553k4JirV0eDuMfi4IcWA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.16.0",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
         "@svgr/webpack": "^6.2.1",
-        "@wordpress/babel-preset-default": "^7.4.0",
-        "@wordpress/browserslist-config": "^5.3.0",
-        "@wordpress/dependency-extraction-webpack-plugin": "^4.3.0",
-        "@wordpress/eslint-plugin": "^13.4.0",
-        "@wordpress/jest-preset-default": "^10.1.0",
-        "@wordpress/npm-package-json-lint-config": "^4.5.0",
-        "@wordpress/postcss-plugins-preset": "^4.4.0",
-        "@wordpress/prettier-config": "^2.3.0",
-        "@wordpress/stylelint-config": "^21.3.0",
+        "@wordpress/babel-preset-default": "^7.6.0",
+        "@wordpress/browserslist-config": "^5.5.0",
+        "@wordpress/dependency-extraction-webpack-plugin": "^4.5.0",
+        "@wordpress/eslint-plugin": "^13.6.0",
+        "@wordpress/jest-preset-default": "^10.3.0",
+        "@wordpress/npm-package-json-lint-config": "^4.7.0",
+        "@wordpress/postcss-plugins-preset": "^4.6.0",
+        "@wordpress/prettier-config": "^2.5.0",
+        "@wordpress/stylelint-config": "^21.5.0",
         "adm-zip": "^0.5.9",
         "babel-jest": "^27.4.5",
         "babel-loader": "^8.2.3",
@@ -4509,22 +4515,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@wordpress/scripts/node_modules/prettier": {
-      "name": "wp-prettier",
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2.tgz",
-      "integrity": "sha512-AV33EzqiFJ3fj+mPlKABN59YFPReLkDxQnj067Z3uEOeRQf3g05WprL0RDuqM7UBhSRo9W1rMSC2KvZmjE5UOA==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/@wordpress/scripts/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4538,9 +4528,9 @@
       }
     },
     "node_modules/@wordpress/stylelint-config": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.3.0.tgz",
-      "integrity": "sha512-bjb7jMafEiPdZ5deq1QdGnxvOLDiRcHqCMDPG6kRflb9TYQ1H1yDBC5r4nUm60wTN/xy/du80zCdNuDe2N2Nrg==",
+      "version": "21.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.5.0.tgz",
+      "integrity": "sha512-qwZyKcM85Ft1KmXgZtySOHrFwCZfR3NkfSEb8XZWYtWdlIwpwmvuBcDJ0iZrfQf8AL5sxkOYwrpsOoHVD5uPKw==",
       "dev": true,
       "dependencies": {
         "stylelint-config-recommended": "^6.0.0",
@@ -4554,9 +4544,9 @@
       }
     },
     "node_modules/@wordpress/warning": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.20.0.tgz",
-      "integrity": "sha512-swTE3rUbk00rddyrQo2sA6yojbzNYUXTntAHbfoF68AC53i7cFunB3Bcod+paDPGR0gq1mr3rfatrWHze8qz3Q==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.22.0.tgz",
+      "integrity": "sha512-BMM4GqiJNIZzh5SIK17EOyilp08mQ+DoKfxL+pl/lpA68jxYUTcKJf0atNbxXKPZHDCWGnQzFwr+huNYOtp4CQ==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -4847,15 +4837,15 @@
       "dev": true
     },
     "node_modules/array-includes": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5",
-        "get-intrinsic": "^1.1.1",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "is-string": "^1.0.7"
       },
       "engines": {
@@ -4884,14 +4874,14 @@
       }
     },
     "node_modules/array.prototype.flat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
@@ -4902,14 +4892,14 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
-      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
@@ -4950,9 +4940,9 @@
       "dev": true
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.12",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.12.tgz",
-      "integrity": "sha512-WrCGV9/b97Pa+jtwf5UGaRjgQIg7OK3D06GnoYoZNcG1Xb8Gt3EfuKjlhh9i/VtT16g6PYjZ69jdJ2g8FxSC4Q==",
+      "version": "10.4.13",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
+      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
       "dev": true,
       "funding": [
         {
@@ -4966,7 +4956,7 @@
       ],
       "dependencies": {
         "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001407",
+        "caniuse-lite": "^1.0.30001426",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -4983,9 +4973,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
-      "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
+      "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5579,9 +5569,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001423",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz",
-      "integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==",
+      "version": "1.0.30001431",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
+      "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==",
       "dev": true,
       "funding": [
         {
@@ -5790,10 +5780,13 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
-      "dev": true
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.6.1.tgz",
+      "integrity": "sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
@@ -6182,9 +6175,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.25.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.5.tgz",
-      "integrity": "sha512-nbm6eZSjm+ZuBQxCUPQKQCoUEfFOXjUZ8dTTyikyKaWrTYmAVbykQfwsKE5dBK88u3QCkCrzsx/PPlKfhsvgpw==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
+      "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -6223,9 +6216,9 @@
       "dev": true
     },
     "node_modules/cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dev": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
@@ -6578,9 +6571,9 @@
       }
     },
     "node_modules/decamelize-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
       "dev": true,
       "dependencies": {
         "decamelize": "^1.1.0",
@@ -6588,6 +6581,9 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/decamelize-keys/node_modules/map-obj": {
@@ -7218,14 +7214,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
-      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
+      "version": "8.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
+      "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.10.5",
+        "@humanwhocodes/config-array": "^0.11.6",
         "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -7241,14 +7238,14 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "glob-parent": "^6.0.1",
+        "glob-parent": "^6.0.2",
         "globals": "^13.15.0",
-        "globby": "^11.1.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
         "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -7767,6 +7764,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint/node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/eslint/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -7840,9 +7846,9 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
@@ -10870,9 +10876,9 @@
       }
     },
     "node_modules/jest-pnp-resolver": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -11851,9 +11857,9 @@
       }
     },
     "node_modules/known-css-properties": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.25.0.tgz",
-      "integrity": "sha512-b0/9J1O9Jcyik1GC6KC42hJ41jKwdO/Mq8Mdo5sYN+IuRTXs2YFHZC3kZSx6ueusqa95x3wLYe/ytKjbAfGixA==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.26.0.tgz",
+      "integrity": "sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==",
       "dev": true
     },
     "node_modules/language-subtag-registry": {
@@ -12719,6 +12725,12 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -13206,28 +13218,28 @@
       }
     },
     "node_modules/object.entries": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
-      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
+      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
-      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
+      "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13237,27 +13249,27 @@
       }
     },
     "node_modules/object.hasown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
-      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
+      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
       "dev": true,
       "dependencies": {
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13723,9 +13735,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
-      "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
+      "version": "8.4.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
       "dev": true,
       "funding": [
         {
@@ -14344,11 +14356,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "name": "wp-prettier",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2.tgz",
+      "integrity": "sha512-AV33EzqiFJ3fj+mPlKABN59YFPReLkDxQnj067Z3uEOeRQf3g05WprL0RDuqM7UBhSRo9W1rMSC2KvZmjE5UOA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -15820,9 +15832,9 @@
       "dev": true
     },
     "node_modules/stack-utils": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "dev": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -15898,18 +15910,18 @@
       "dev": true
     },
     "node_modules/string.prototype.matchall": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
-      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
+      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
-        "get-intrinsic": "^1.1.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.4.1",
+        "regexp.prototype.flags": "^1.4.3",
         "side-channel": "^1.0.4"
       },
       "funding": {
@@ -16050,15 +16062,15 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "14.14.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.14.0.tgz",
-      "integrity": "sha512-yUI+4xXfPHVnueYddSQ/e1GuEA/2wVhWQbGj16AmWLtQJtn28lVxfS4b0CsWyVRPgd3Auzi0NXOthIEUhtQmmA==",
+      "version": "14.15.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.15.0.tgz",
+      "integrity": "sha512-JOgDAo5QRsqiOZPZO+B9rKJvBm64S0xasbuRPAbPs6/vQDgDCnZLIiw6XcAS6GQKk9k1sBWR6rmH3Mfj8OknKg==",
       "dev": true,
       "dependencies": {
         "@csstools/selector-specificity": "^2.0.2",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
-        "cosmiconfig": "^7.0.1",
+        "cosmiconfig": "^7.1.0",
         "css-functions-list": "^3.1.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.2.12",
@@ -16072,13 +16084,13 @@
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.25.0",
+        "known-css-properties": "^0.26.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^9.0.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.17",
+        "postcss": "^8.4.19",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^6.0.0",
@@ -16090,7 +16102,7 @@
         "style-search": "^0.1.0",
         "supports-hyperlinks": "^2.3.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.8.0",
+        "table": "^6.8.1",
         "v8-compile-cache": "^2.3.0",
         "write-file-atomic": "^4.0.2"
       },
@@ -16412,9 +16424,9 @@
       "dev": true
     },
     "node_modules/table": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
-      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
+      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.0.1",
@@ -16428,9 +16440,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -16816,9 +16828,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -19226,13 +19238,13 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.19.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.19.6.tgz",
-      "integrity": "sha512-oWNn1ZlGde7b4i/3tnixpH9qI0bOAACiUs+KEES4UUCnsPjVWFlWdLV/iwJuPC2qp3EowbAqsm+0XqNwnwYhxA==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.1.tgz",
+      "integrity": "sha512-CGulbEDcg/ND1Im7fUNRZdGXmX2MTWVVZacQi/6DiKE5HNwZ3aVTm5PV4lO8HHz0B2h8WQyvKKjbX5XgTtydsg==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.25.1",
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.10"
       }
     },
     "@babel/template": {
@@ -19370,14 +19382,14 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
-      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
+      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5"
       }
     },
     "@humanwhocodes/module-importer": {
@@ -20078,9 +20090,9 @@
       "dev": true
     },
     "@sinonjs/commons": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
+      "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -20242,9 +20254,9 @@
       "dev": true
     },
     "@types/babel__core": {
-      "version": "7.1.19",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
-      "integrity": "sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==",
+      "version": "7.1.20",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.20.tgz",
+      "integrity": "sha512-PVb6Bg2QuscZ30FvOU7z4guG6c926D9YRvOxEaelzndpMsvP+YM74Q/dAFASpg2l6+XLalxSGxcq/lrgYWZtyQ==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -20494,9 +20506,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.50",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.50.tgz",
-      "integrity": "sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==",
+      "version": "17.0.52",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.52.tgz",
+      "integrity": "sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -20505,9 +20517,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.17",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.17.tgz",
-      "integrity": "sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==",
+      "version": "17.0.18",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.18.tgz",
+      "integrity": "sha512-rLVtIfbwyur2iFKykP2w0pl/1unw26b5td16d5xMgp7/yjTHomkyxPYChFoCr/FtEX1lN9wY6lFj1qvKdS5kDw==",
       "dev": true,
       "requires": {
         "@types/react": "^17"
@@ -20526,9 +20538,9 @@
       "dev": true
     },
     "@types/semver": {
-      "version": "7.3.12",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
-      "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
     },
     "@types/serve-index": {
@@ -20662,16 +20674,17 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.1.tgz",
-      "integrity": "sha512-FsWboKkWdytGiXT5O1/R9j37YgcjO8MKHSUmWnIEjVaz0krHkplPnYi7mwdb+5+cs0toFNQb0HIrN7zONdIEWg==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.43.0.tgz",
+      "integrity": "sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.40.1",
-        "@typescript-eslint/type-utils": "5.40.1",
-        "@typescript-eslint/utils": "5.40.1",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/type-utils": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
@@ -20704,62 +20717,62 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.40.1.tgz",
-      "integrity": "sha512-lynjgnQuoCgxtYgYWjoQqijk0kYQNiztnVhoqha3N0kMYFVPURidzCq2vn9XvUUu2XxP130ZRKVDKyeGa2bhbw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.43.0.tgz",
+      "integrity": "sha512-WkT637CumTJbm/hRbFfnHBMgfUYTKr08LitVsD7gQId7bi6rnkx3pu3jac67lmp5ObW4MpJ9SNFZAIOUB/Qbsw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.40.1"
+        "@typescript-eslint/utils": "5.43.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.40.1.tgz",
-      "integrity": "sha512-IK6x55va5w4YvXd4b3VrXQPldV9vQTxi5ov+g4pMANsXPTXOcfjx08CRR1Dfrcc51syPtXHF5bgLlMHYFrvQtg==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.43.0.tgz",
+      "integrity": "sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.40.1",
-        "@typescript-eslint/types": "5.40.1",
-        "@typescript-eslint/typescript-estree": "5.40.1",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.1.tgz",
-      "integrity": "sha512-jkn4xsJiUQucI16OLCXrLRXDZ3afKhOIqXs4R3O+M00hdQLKR58WuyXPZZjhKLFCEP2g+TXdBRtLQ33UfAdRUg==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.43.0.tgz",
+      "integrity": "sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.40.1",
-        "@typescript-eslint/visitor-keys": "5.40.1"
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/visitor-keys": "5.43.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.40.1.tgz",
-      "integrity": "sha512-DLAs+AHQOe6n5LRraXiv27IYPhleF0ldEmx6yBqBgBLaNRKTkffhV1RPsjoJBhVup2zHxfaRtan8/YRBgYhU9Q==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.43.0.tgz",
+      "integrity": "sha512-K21f+KY2/VvYggLf5Pk4tgBOPs2otTaIHy2zjclo7UZGLyFH86VfUOm5iq+OtDtxq/Zwu2I3ujDBykVW4Xtmtg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.40.1",
-        "@typescript-eslint/utils": "5.40.1",
+        "@typescript-eslint/typescript-estree": "5.43.0",
+        "@typescript-eslint/utils": "5.43.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.1.tgz",
-      "integrity": "sha512-Icg9kiuVJSwdzSQvtdGspOlWNjVDnF3qVIKXdJ103o36yRprdl3Ge5cABQx+csx960nuMF21v8qvO31v9t3OHw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.43.0.tgz",
+      "integrity": "sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.1.tgz",
-      "integrity": "sha512-5QTP/nW5+60jBcEPfXy/EZL01qrl9GZtbgDZtDPlfW5zj/zjNrdI2B5zMUHmOsfvOr2cWqwVdWjobCiHcedmQA==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.43.0.tgz",
+      "integrity": "sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.40.1",
-        "@typescript-eslint/visitor-keys": "5.40.1",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/visitor-keys": "5.43.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -20794,16 +20807,16 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.40.1.tgz",
-      "integrity": "sha512-a2TAVScoX9fjryNrW6BZRnreDUszxqm9eQ9Esv8n5nXApMW0zeANUYlwh/DED04SC/ifuBvXgZpIK5xeJHQ3aw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.43.0.tgz",
+      "integrity": "sha512-8nVpA6yX0sCjf7v/NDfeaOlyaIIqL7OaIGOWSPFqUKK59Gnumd3Wa+2l8oAaYO2lk0sO+SbWFWRSvhu8gLGv4A==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.40.1",
-        "@typescript-eslint/types": "5.40.1",
-        "@typescript-eslint/typescript-estree": "5.40.1",
+        "@typescript-eslint/scope-manager": "5.43.0",
+        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.43.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -20836,12 +20849,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.1.tgz",
-      "integrity": "sha512-A2DGmeZ+FMja0geX5rww+DpvILpwo1OsiQs0M+joPWJYsiEFBLsH0y1oFymPNul6Z5okSmHpP4ivkc2N0Cgfkw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.43.0.tgz",
+      "integrity": "sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.40.1",
+        "@typescript-eslint/types": "5.43.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "dependencies": {
@@ -21023,16 +21036,16 @@
       "requires": {}
     },
     "@wordpress/babel-plugin-import-jsx-pragma": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.3.0.tgz",
-      "integrity": "sha512-7AnWnpItOqH5YEcFA3RgxeOlb96R8KDWDPAZjZ6TpsdOVjFynT8H3Buc4v127BHmxuxKGyd2vxPIQIzC9dLzOw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.5.0.tgz",
+      "integrity": "sha512-/5TZUHgy4fh7L1aQJPQ8dKjaWBio41uiR4Y9aGH0oeg6pXdQlEOtbAXQtTAHeGyE1vJMYJUVHdRWdLocpGQWgA==",
       "dev": true,
       "requires": {}
     },
     "@wordpress/babel-preset-default": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.4.0.tgz",
-      "integrity": "sha512-7drcVBIajDE8s3At7yUr9UdHROYkfPYgR4OaG+EugDn9MzuDIEsGalnazDYwvjerLAwsf8S/S8o34bi6IrthYQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.6.0.tgz",
+      "integrity": "sha512-DVwF85jvgGR6ExSIOsJKBj2v5vWO2AsrKUs5Vg9vTG7YdkR23JENBOiORYPgYWIdbK7JmSIXEPyfL7HpdvNp9A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.16.0",
@@ -21041,30 +21054,30 @@
         "@babel/preset-env": "^7.16.0",
         "@babel/preset-typescript": "^7.16.0",
         "@babel/runtime": "^7.16.0",
-        "@wordpress/babel-plugin-import-jsx-pragma": "^4.3.0",
-        "@wordpress/browserslist-config": "^5.3.0",
-        "@wordpress/element": "^4.18.0",
-        "@wordpress/warning": "^2.20.0",
+        "@wordpress/babel-plugin-import-jsx-pragma": "^4.5.0",
+        "@wordpress/browserslist-config": "^5.5.0",
+        "@wordpress/element": "^4.20.0",
+        "@wordpress/warning": "^2.22.0",
         "browserslist": "^4.17.6",
         "core-js": "^3.19.1"
       }
     },
     "@wordpress/base-styles": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.11.0.tgz",
-      "integrity": "sha512-KGHGtOP8q4u3DhlDsw4mMxlcnqxFPMsPa2GrbFBFgFEMeC/v9XMJAAY97V93D5Tbz1JaWBXjQHI+FwPFuyvCHQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.13.0.tgz",
+      "integrity": "sha512-ivIj7cANk0ML+krX+MnprJMTvLy9l9k/TCuTyrYKx9JRbo2khq+eOvuTsdB9cKcTh7/xMMwNaJ7dn5RAYRb/VQ==",
       "dev": true
     },
     "@wordpress/browserslist-config": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.3.0.tgz",
-      "integrity": "sha512-FIhYWu36TrZ49W+knaRwhw3Q+cxaTDEzSaiE83qMDeAPJytT/UaedoJULt5MfxUtfaKLmUa8bPjSFORxoxwbvQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.5.0.tgz",
+      "integrity": "sha512-M3BhWQ+R8AK2g861hOtLTp/WnjcXPddiNzoMHR5zQOhcuSmgfP4dNJIJUWIVRPhqpES2EGcc30F9MIEyV27WiQ==",
       "dev": true
     },
     "@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.3.0.tgz",
-      "integrity": "sha512-GVQlG0kwPDQj4sYJrYAOuvc0ggrpH75ljV+xGNdy3KPMmrVzhaYEnDSuajlOvpcFyoueMagRJOH84StB76tcMg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.5.0.tgz",
+      "integrity": "sha512-eLzWb/TftHiPzl8ZgwuCPhW0ir9/1VVzVgsag7DyhjyrESLD4YWRqTaE1M1qf6lRP9kjYvBLFZ0TKuLT90Iayg==",
       "dev": true,
       "requires": {
         "json2php": "^0.0.5",
@@ -21072,15 +21085,15 @@
       }
     },
     "@wordpress/element": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.18.0.tgz",
-      "integrity": "sha512-+3gA4RTD/EDj1h2y/qikh+h0uCUxhShfM7QoDngKOBNSTZHqc0W2p6IMEe+AMdrmu8tyZboTJW/eONjUHE4n7g==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.20.0.tgz",
+      "integrity": "sha512-Ou7EoGtGe4FUL6fKALINXJLKoSfyWTBJzkJfN2HzSgM1wira9EuWahl8MQN0HAUaWeOoDqMKPvnglfS+kC8JLA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.0",
         "@types/react": "^17.0.37",
         "@types/react-dom": "^17.0.11",
-        "@wordpress/escape-html": "^2.20.0",
+        "@wordpress/escape-html": "^2.22.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^17.0.2",
@@ -21088,25 +21101,25 @@
       }
     },
     "@wordpress/escape-html": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.20.0.tgz",
-      "integrity": "sha512-bhHkFQrEkuJjhSB6OlQq/Kq+43k8E6JwUw/pCDAjJX2uU/DDG3tW3eftYn2ae7W23bPrNEs1/qULWzbaziPQnw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.22.0.tgz",
+      "integrity": "sha512-GUo6VLugIZxen1rdYuotvz6Vqa+5fNtVelNjXLwDqRu0iY2RXeoTux9V5bZWXPnGb54ryqfYmR4gH6F8xZhWzQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.0"
       }
     },
     "@wordpress/eslint-plugin": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-13.4.0.tgz",
-      "integrity": "sha512-318QjzGildIdHJVAT26CFkYzoXW8w3RUTNzDJrJ+Hx9EHCg2TNOrUwW4rLwp9h32Gsw/QerhF9wzE/pueoYdYw==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-13.6.0.tgz",
+      "integrity": "sha512-GIW4AHb0IC9VA6y8IRGQpADxpvdG+K0an/ZpzlYmBudql7YuLlUmp9rLpBlSvHf9iGX81OUYl9B63XEItPzGEw==",
       "dev": true,
       "requires": {
         "@babel/eslint-parser": "^7.16.0",
         "@typescript-eslint/eslint-plugin": "^5.3.0",
         "@typescript-eslint/parser": "^5.3.0",
-        "@wordpress/babel-preset-default": "^7.4.0",
-        "@wordpress/prettier-config": "^2.3.0",
+        "@wordpress/babel-preset-default": "^7.6.0",
+        "@wordpress/prettier-config": "^2.5.0",
         "cosmiconfig": "^7.0.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.25.2",
@@ -21138,9 +21151,9 @@
       }
     },
     "@wordpress/jest-console": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-6.3.0.tgz",
-      "integrity": "sha512-WnpXPqRNTo7OBnUEvC7mJufEZUNZXlScnRx3MHFOErzhCzed03t+x2hQHamhYpUrE2hZLwfKugN9WYDzh2mTtA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-6.5.0.tgz",
+      "integrity": "sha512-DqqilY6+FMJHcrUJhAu059iTIFKOXqoWuh0X7MXTGyW4S29n6V4Tzyy8TNhn074R3hjCIqgXo3yF3QXL8uLefQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.0",
@@ -21148,57 +21161,57 @@
       }
     },
     "@wordpress/jest-preset-default": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-10.1.0.tgz",
-      "integrity": "sha512-FzMUu31TGv9nLjBTNnMD6EZRU8oYEcDVCg/oUHBv2Rc9GipOgVZB5yRpZA1oAVSxirIvenv0wQ4PGouPAPgcIQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-10.3.0.tgz",
+      "integrity": "sha512-ObyBTM0tIVONU6xmBkgCcl8mrY9hAk+2ZuIrwze5DHVx6dZzeASxouxbgutHOQNu7cHMtVNJ7O5I1XZ7KlhWig==",
       "dev": true,
       "requires": {
-        "@wordpress/jest-console": "^6.3.0",
+        "@wordpress/jest-console": "^6.5.0",
         "babel-jest": "^27.4.5"
       }
     },
     "@wordpress/npm-package-json-lint-config": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.5.0.tgz",
-      "integrity": "sha512-UdPtZmvBKI6ygsLsGMxDJjt9H2S2M//rHSSHPMpy5nmLGft890c0+cQwoIPhJpGis3pC5r1Bh8zCrzVZqoBHVQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.7.0.tgz",
+      "integrity": "sha512-sNNaMxA9NwC9ns1Ez/Fd61SULUtDjKWalDMoRX32RpSeNKmcAs2s7vAjDm7xY0NoXX6DPKnU1iftE2mu/8YqVg==",
       "dev": true,
       "requires": {}
     },
     "@wordpress/postcss-plugins-preset": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.4.0.tgz",
-      "integrity": "sha512-KAy+HqPbl/yHGsvWgzfRPonQM7hJ1Zy6ABuwFAk/gqTy2v28InBhyZLSVJAjxMgh0Cxfyfgn+XYIHwlzMTvTXg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.6.0.tgz",
+      "integrity": "sha512-d7wx4lSFGXQBdaKq0SE987IYeC6YhQOr3TlUG1fA9+DFwCpzm3zYxAiDQ8QCMY1y4Di9+3/GgUlaD6MJc60BxA==",
       "dev": true,
       "requires": {
-        "@wordpress/base-styles": "^4.11.0",
+        "@wordpress/base-styles": "^4.13.0",
         "autoprefixer": "^10.2.5"
       }
     },
     "@wordpress/prettier-config": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-2.3.0.tgz",
-      "integrity": "sha512-eqeiUvwogvtVTFZ+H0ZRY2EZNBXiyw3XbqGbi4Om15yAaMrnlm8NfUow2yHepYKkW/wWVr1tqBFQN7gZBPtYCQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-2.5.0.tgz",
+      "integrity": "sha512-YI7CwUScwFW3N6PCH6IH2tvnfgkhAYEnYDOJ30JG2P0E3vXG6lnvrdVpQyKlEsGqUDy3FBcTPIP/m3/SHpp6Iw==",
       "dev": true,
       "requires": {}
     },
     "@wordpress/scripts": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-24.4.0.tgz",
-      "integrity": "sha512-MpF2dFknFIEMIZV8lCNlfktHV4WNrUZDirKXkKafdYWxtiuPn8vXgvU9E2tI1PERpaMEQvx75ot5LBB2C5TErw==",
+      "version": "24.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-24.6.0.tgz",
+      "integrity": "sha512-IbJkihQsjaZz03qyTPcjRF2FWiVVcCm90eL/QutO9cSmZbqfAT1hwNSZIEakiy7GK553k4JirV0eDuMfi4IcWA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.16.0",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
         "@svgr/webpack": "^6.2.1",
-        "@wordpress/babel-preset-default": "^7.4.0",
-        "@wordpress/browserslist-config": "^5.3.0",
-        "@wordpress/dependency-extraction-webpack-plugin": "^4.3.0",
-        "@wordpress/eslint-plugin": "^13.4.0",
-        "@wordpress/jest-preset-default": "^10.1.0",
-        "@wordpress/npm-package-json-lint-config": "^4.5.0",
-        "@wordpress/postcss-plugins-preset": "^4.4.0",
-        "@wordpress/prettier-config": "^2.3.0",
-        "@wordpress/stylelint-config": "^21.3.0",
+        "@wordpress/babel-preset-default": "^7.6.0",
+        "@wordpress/browserslist-config": "^5.5.0",
+        "@wordpress/dependency-extraction-webpack-plugin": "^4.5.0",
+        "@wordpress/eslint-plugin": "^13.6.0",
+        "@wordpress/jest-preset-default": "^10.3.0",
+        "@wordpress/npm-package-json-lint-config": "^4.7.0",
+        "@wordpress/postcss-plugins-preset": "^4.6.0",
+        "@wordpress/prettier-config": "^2.5.0",
+        "@wordpress/stylelint-config": "^21.5.0",
         "adm-zip": "^0.5.9",
         "babel-jest": "^27.4.5",
         "babel-loader": "^8.2.3",
@@ -21284,12 +21297,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "prettier": {
-          "version": "npm:wp-prettier@2.6.2",
-          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2.tgz",
-          "integrity": "sha512-AV33EzqiFJ3fj+mPlKABN59YFPReLkDxQnj067Z3uEOeRQf3g05WprL0RDuqM7UBhSRo9W1rMSC2KvZmjE5UOA==",
-          "dev": true
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -21302,9 +21309,9 @@
       }
     },
     "@wordpress/stylelint-config": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.3.0.tgz",
-      "integrity": "sha512-bjb7jMafEiPdZ5deq1QdGnxvOLDiRcHqCMDPG6kRflb9TYQ1H1yDBC5r4nUm60wTN/xy/du80zCdNuDe2N2Nrg==",
+      "version": "21.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.5.0.tgz",
+      "integrity": "sha512-qwZyKcM85Ft1KmXgZtySOHrFwCZfR3NkfSEb8XZWYtWdlIwpwmvuBcDJ0iZrfQf8AL5sxkOYwrpsOoHVD5uPKw==",
       "dev": true,
       "requires": {
         "stylelint-config-recommended": "^6.0.0",
@@ -21312,9 +21319,9 @@
       }
     },
     "@wordpress/warning": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.20.0.tgz",
-      "integrity": "sha512-swTE3rUbk00rddyrQo2sA6yojbzNYUXTntAHbfoF68AC53i7cFunB3Bcod+paDPGR0gq1mr3rfatrWHze8qz3Q==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.22.0.tgz",
+      "integrity": "sha512-BMM4GqiJNIZzh5SIK17EOyilp08mQ+DoKfxL+pl/lpA68jxYUTcKJf0atNbxXKPZHDCWGnQzFwr+huNYOtp4CQ==",
       "dev": true
     },
     "@xtuc/ieee754": {
@@ -21531,15 +21538,15 @@
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5",
-        "get-intrinsic": "^1.1.1",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "is-string": "^1.0.7"
       }
     },
@@ -21556,26 +21563,26 @@
       "dev": true
     },
     "array.prototype.flat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
       }
     },
     "array.prototype.flatmap": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
-      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
       }
     },
@@ -21604,13 +21611,13 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "10.4.12",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.12.tgz",
-      "integrity": "sha512-WrCGV9/b97Pa+jtwf5UGaRjgQIg7OK3D06GnoYoZNcG1Xb8Gt3EfuKjlhh9i/VtT16g6PYjZ69jdJ2g8FxSC4Q==",
+      "version": "10.4.13",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
+      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
       "dev": true,
       "requires": {
         "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001407",
+        "caniuse-lite": "^1.0.30001426",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -21618,9 +21625,9 @@
       }
     },
     "axe-core": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
-      "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
+      "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==",
       "dev": true
     },
     "axios": {
@@ -22064,9 +22071,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001423",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz",
-      "integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==",
+      "version": "1.0.30001431",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
+      "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==",
       "dev": true
     },
     "capital-case": {
@@ -22222,9 +22229,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.6.1.tgz",
+      "integrity": "sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==",
       "dev": true
     },
     "cjs-module-lexer": {
@@ -22535,9 +22542,9 @@
       }
     },
     "core-js": {
-      "version": "3.25.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.5.tgz",
-      "integrity": "sha512-nbm6eZSjm+ZuBQxCUPQKQCoUEfFOXjUZ8dTTyikyKaWrTYmAVbykQfwsKE5dBK88u3QCkCrzsx/PPlKfhsvgpw==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
+      "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA==",
       "dev": true
     },
     "core-js-compat": {
@@ -22562,9 +22569,9 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dev": true,
       "requires": {
         "@types/parse-json": "^4.0.0",
@@ -22828,9 +22835,9 @@
       "dev": true
     },
     "decamelize-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
       "dev": true,
       "requires": {
         "decamelize": "^1.1.0",
@@ -23323,14 +23330,15 @@
       }
     },
     "eslint": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
-      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
+      "version": "8.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
+      "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.10.5",
+        "@humanwhocodes/config-array": "^0.11.6",
         "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -23346,14 +23354,14 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "glob-parent": "^6.0.1",
+        "glob-parent": "^6.0.2",
         "globals": "^13.15.0",
-        "globby": "^11.1.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
         "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -23454,6 +23462,12 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-path-inside": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+          "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
           "dev": true
         },
         "js-yaml": {
@@ -23773,9 +23787,9 @@
       "dev": true
     },
     "espree": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-      "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.0",
@@ -26011,9 +26025,9 @@
       }
     },
     "jest-pnp-resolver": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
       "dev": true,
       "requires": {}
     },
@@ -26759,9 +26773,9 @@
       "dev": true
     },
     "known-css-properties": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.25.0.tgz",
-      "integrity": "sha512-b0/9J1O9Jcyik1GC6KC42hJ41jKwdO/Mq8Mdo5sYN+IuRTXs2YFHZC3kZSx6ueusqa95x3wLYe/ytKjbAfGixA==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.26.0.tgz",
+      "integrity": "sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==",
       "dev": true
     },
     "language-subtag-registry": {
@@ -27429,6 +27443,12 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
+    },
     "negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -27802,46 +27822,46 @@
       }
     },
     "object.entries": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
-      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
+      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       }
     },
     "object.fromentries": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
-      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
+      "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       }
     },
     "object.hasown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
-      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
+      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       }
     },
     "object.values": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       }
     },
     "obuf": {
@@ -28180,9 +28200,9 @@
       }
     },
     "postcss": {
-      "version": "8.4.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
-      "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
+      "version": "8.4.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.4",
@@ -28563,11 +28583,10 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true,
-      "peer": true
+      "version": "npm:wp-prettier@2.6.2",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2.tgz",
+      "integrity": "sha512-AV33EzqiFJ3fj+mPlKABN59YFPReLkDxQnj067Z3uEOeRQf3g05WprL0RDuqM7UBhSRo9W1rMSC2KvZmjE5UOA==",
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -29690,9 +29709,9 @@
       "dev": true
     },
     "stack-utils": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
@@ -29757,18 +29776,18 @@
       }
     },
     "string.prototype.matchall": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
-      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
+      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
-        "get-intrinsic": "^1.1.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.4.1",
+        "regexp.prototype.flags": "^1.4.3",
         "side-channel": "^1.0.4"
       }
     },
@@ -29867,15 +29886,15 @@
       }
     },
     "stylelint": {
-      "version": "14.14.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.14.0.tgz",
-      "integrity": "sha512-yUI+4xXfPHVnueYddSQ/e1GuEA/2wVhWQbGj16AmWLtQJtn28lVxfS4b0CsWyVRPgd3Auzi0NXOthIEUhtQmmA==",
+      "version": "14.15.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.15.0.tgz",
+      "integrity": "sha512-JOgDAo5QRsqiOZPZO+B9rKJvBm64S0xasbuRPAbPs6/vQDgDCnZLIiw6XcAS6GQKk9k1sBWR6rmH3Mfj8OknKg==",
       "dev": true,
       "requires": {
         "@csstools/selector-specificity": "^2.0.2",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
-        "cosmiconfig": "^7.0.1",
+        "cosmiconfig": "^7.1.0",
         "css-functions-list": "^3.1.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.2.12",
@@ -29889,13 +29908,13 @@
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.25.0",
+        "known-css-properties": "^0.26.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^9.0.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.17",
+        "postcss": "^8.4.19",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^6.0.0",
@@ -29907,7 +29926,7 @@
         "style-search": "^0.1.0",
         "supports-hyperlinks": "^2.3.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.8.0",
+        "table": "^6.8.1",
         "v8-compile-cache": "^2.3.0",
         "write-file-atomic": "^4.0.2"
       },
@@ -30148,9 +30167,9 @@
       "dev": true
     },
     "table": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
-      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
+      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
       "dev": true,
       "requires": {
         "ajv": "^8.0.1",
@@ -30161,9 +30180,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "version": "8.11.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+          "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -30457,9 +30476,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true,
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "npm": ">=7.0"
   },
   "devDependencies": {
-    "@wordpress/browserslist-config": "latest",
-    "@wordpress/scripts": "^24.4.0",
+    "@wordpress/browserslist-config": "^5.5.0",
+    "@wordpress/scripts": "^24.6.0",
     "npm-run-all": "^4.1.5"
   },
   "browserslist": [
@@ -34,7 +34,7 @@
     "lint:styles": "npm-run-all lint:styles:* --sequential",
     "lint:styles:theme": "wp-scripts lint-style themes/$npm_package_name/**/*.{css,sass,scss} !themes/$npm_package_name/style.css --allow-empty-input --report-descriptionless-disables --report-invalid-scope-disables --report-needless-disables",
     "lint:styles:mu-plugins": "wp-scripts lint-style mu-plugins/**/*.{css,sass,scss} --allow-empty-input --report-descriptionless-disables --report-invalid-scope-disables --report-needless-disables",
-    "packages-update": "wp-scripts packages-update"
+    "packages-update": "wp-scripts packages-update",
     "check-engines": "wp-scripts check-engines",
     "check-licenses": "wp-scripts check-licenses"
   }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `ESLint`, `Stylelint`, and `Prettier` together with their `@wordpress/<package>-config` package.
* Add `package.json` commands for linting script and style files. 
* Add `package.json` commands for fixing linting errors on script and style files. 

#### Testing instructions

* Create files inside the theme or the mu-plugins folder that is purposefully riddled with errors, then run the commands to validate that the errors are caught (and optionally fixed).

#### Discussion points

* Currently, the linter/beautifier packages themselves are added by `@wordpress/scripts` only. However, I opted for explicitly including the config packages although those are included too. The reasoning behind this was to make it clear where those configs are coming from. If a project doesn't use `@wordpress/scripts`, then it should be replaced by `ESLint`, `Stylelint`, and `Prettier`.
* I opted to use `eslint`, `stylelint`, and `prettier` directly instead of relying [on the scripts provided by `wp-scripts`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#setup) to decouple the logic from (and dependency on) it. It should be possible though to rely entirely on `wp-scripts` ~~-- **I'll investigate this briefly later on**~~

Notes on #7: I underestimated how versatile `wp-scripts` really is. I think we should really leverage it to simplify linting and formatting without loss of configurability.
