### PR TITLE
Linting and formatting based on WP Scripts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,0 @@
-{
-  "extends": [ "plugin:@wordpress/eslint-plugin/recommended" ],
-  "ignorePatterns": [ "**/build/**" ],
-  "globals": {
-    "jQuery": true
-  }
-}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-build
-vendor

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,1 +1,0 @@
-module.exports = require( '@wordpress/prettier-config' );

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,4 +1,0 @@
-{
-  "extends": [ "@wordpress/stylelint-config/scss" ],
-  "ignoreFiles": [ "**/build/**" ]
-}

--- a/package.json
+++ b/package.json
@@ -7,27 +7,24 @@
     "url": "https://github.com/a8cteam51/build-processes-demo/issues"
   },
   "devDependencies": {
-    "@wordpress/eslint-plugin": "^13.4.0",
-    "@wordpress/prettier-config": "^2.3.0",
     "@wordpress/scripts": "^24.4.0",
-    "@wordpress/stylelint-config": "^21.3.0",
     "npm-run-all": "^4.1.5"
   },
   "scripts": {
     "format:scripts": "npm-run-all format:scripts:* --sequential",
-    "format:scripts:theme": "prettier --write --no-error-on-unmatched-pattern themes/$npm_package_name/**/*.{js,jsx,ts,tsx,json,yml,yaml}",
-    "format:scripts:mu-plugins": "prettier --write --no-error-on-unmatched-pattern mu-plugins/**/*.{js,jsx,ts,tsx,json,yml,yaml}",
+    "format:scripts:theme": "wp-scripts format themes/$npm_package_name --no-error-on-unmatched-pattern",
+    "format:scripts:mu-plugins": "wp-scripts format mu-plugins --no-error-on-unmatched-pattern",
     "format:styles": "npm-run-all format:styles:* --sequential",
     "format:styles:theme": "npm run lint:styles:theme -- --fix",
     "format:styles:mu-plugins": "npm run lint:styles:mu-plugins -- --fix",
     "lint:pkg-json": "wp-scripts lint-pkg-json",
     "lint:readme-md": "wp-scripts lint-md-docs README.md",
     "lint:scripts": "npm-run-all lint:scripts:* --sequential",
-    "lint:scripts:theme": "eslint themes/$npm_package_name/**/*.{js,jsx,ts,tsx} --no-error-on-unmatched-pattern",
-    "lint:scripts:mu-plugins": "eslint mu-plugins/**/*.{js,jsx,ts,tsx} --no-error-on-unmatched-pattern",
+    "lint:scripts:theme": "wp-scripts lint-js themes/$npm_package_name --no-error-on-unmatched-pattern",
+    "lint:scripts:mu-plugins": "wp-scripts lint-js mu-plugins --no-error-on-unmatched-pattern",
     "lint:styles": "npm-run-all lint:styles:* --sequential",
-    "lint:styles:theme": "stylelint themes/$npm_package_name/**/*.{css,sass,scss} !themes/$npm_package_name/style.css --allow-empty-input --report-descriptionless-disables --report-invalid-scope-disables --report-needless-disables",
-    "lint:styles:mu-plugins": "stylelint mu-plugins/**/*.{css,sass,scss} --allow-empty-input --report-descriptionless-disables --report-invalid-scope-disables --report-needless-disables",
+    "lint:styles:theme": "wp-scripts lint-style themes/$npm_package_name/**/*.{css,sass,scss} !themes/$npm_package_name/style.css --allow-empty-input --report-descriptionless-disables --report-invalid-scope-disables --report-needless-disables",
+    "lint:styles:mu-plugins": "wp-scripts lint-style mu-plugins/**/*.{css,sass,scss} --allow-empty-input --report-descriptionless-disables --report-invalid-scope-disables --report-needless-disables",
     "packages-update": "wp-scripts packages-update"
   }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `wp-scripts` wrapper instead of relying directly on `eslint`, `prettier`, and `stylelint`.

#### Testing instructions

* Same as in #6 

#### Notes

* `wp-scripts` automatically ignores everything inside a `build` folder, as well as anything inside `node_modules` and `vendor`.
* it's possible to overwrite the config for the linters/beautifiers used by `wp-scripts` by providing their config files or respective config entries in the `package.json` file
