### PR TITLE
Proposal: Include WordPress as a Composer dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "ext-json": "*"
   },
   "require-dev": {
+    "johnpbloch/wordpress-core": "*",
     "wpackagist-theme/blockbase": "*",
     "wpackagist-plugin/woocommerce": "*",
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "646db411ebbe408a566437a280a79972",
+    "content-hash": "b605582720ea93beefe0fae0e63ef9d4",
     "packages": [],
     "packages-dev": [
         {
@@ -439,6 +439,54 @@
                 }
             ],
             "time": "2022-10-18T15:00:10+00:00"
+        },
+        {
+            "name": "johnpbloch/wordpress-core",
+            "version": "6.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/johnpbloch/wordpress-core.git",
+                "reference": "c9688597721b8579f3c29028e572a7b9753db893"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/c9688597721b8579f3c29028e572a7b9753db893",
+                "reference": "c9688597721b8579f3c29028e572a7b9753db893",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.6.20"
+            },
+            "provide": {
+                "wordpress/core-implementation": "6.1.1"
+            },
+            "type": "wordpress-core",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "WordPress Community",
+                    "homepage": "https://wordpress.org/about/"
+                }
+            ],
+            "description": "WordPress is open source software you can use to create a beautiful website, blog, or app.",
+            "homepage": "https://wordpress.org/",
+            "keywords": [
+                "blog",
+                "cms",
+                "wordpress"
+            ],
+            "support": {
+                "forum": "https://wordpress.org/support/",
+                "irc": "irc://irc.freenode.net/wordpress",
+                "issues": "https://core.trac.wordpress.org/",
+                "source": "https://core.trac.wordpress.org/browser",
+                "wiki": "https://codex.wordpress.org/"
+            },
+            "time": "2022-11-15T19:11:58+00:00"
         },
         {
             "name": "mck89/peast",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Include the package `johnpbloch/wordpress-core` as a Composer dev dependency.

#### Testing instructions

* Install Composer packages. The latest version of WordPress should now be available inside `/vendor/johnpbloch/wordpress-core`

#### Reasoning

Similar to how it can be useful to have easy access to the parent theme's code and to various plugins' code while debugging and/or working on something, having the WP code easily searchable can be an advantage too.

Currently, I installed the package globally but that has a couple of disadvantages:

* It's only possible to browse the code of one version of WP. Pressable sites always auto-update, but that is not the case on other hosts like WPEngine.
* It's a bit more difficult to have to open a second VS Code window that loads the WP folder to search through it. Or even add it as an external dependency in PHPStorm since the path is very different. This is at best an inconvenience, not a show-stopper though.
